### PR TITLE
Scanner failure if parameter trace not available

### DIFF
--- a/scanner/scanner3.py
+++ b/scanner/scanner3.py
@@ -60,6 +60,8 @@ class Scanner3(BackgroundTaskThread):
                                 keys = [par_key]
                                 current_rule = cur_rule.copy()
                             for param_key in keys:
+                                if param_key not in trace:
+                                    continue
                                 for check_key in current_rule[param_key]:
                                     # This takes the approach that if anything is false, break
                                     if type(current_rule[param_key][check_key]) is list:


### PR DESCRIPTION
When Scanner evaluates results, it assumes all parameters will have a trace. This is however not always the case. For some binaries (I can provide a sample separately), trace is available for e.g.  '1' and '2', but not '0'. When that occurs, scan prematurely ends with *KeyError '0'* on line:

```python
    if self.is_in_array(trace[param_key]["affected_by"],current_rule[param_key][check_key]):
```

As a quick fix, I propose to add a check on trace availability. In long term, it could be better if all parameters would always have at least some basic trace.