### PR TITLE
UAF Invalid regular expressions for relevant variables

### DIFF
--- a/scanner/free_scanner2.py
+++ b/scanner/free_scanner2.py
@@ -181,7 +181,12 @@ class FreeScanner2(BackgroundTaskThread):
             for v in vars["vars"]:
                 # Lol but worth a try :D
                 tmp_val = tmp_val.replace(str(v),str(v)+"(:\\d+\\.\\w+)?\\b")
-            vars["possible_values"].append(tmp_val)        
+            try:
+                # validate resulting regex
+                re.compile(tmp_val)
+                vars["possible_values"].append(tmp_val)
+            except re.error:
+                pass
         return vars
 
     def is_in_loop(self,instruction):


### PR DESCRIPTION
In some cases, UAF generates invalid regular expressions for *possible_values*. Below is one example:

```
(:\d+\.\w+)?\bv(:\d+\.\w+)?\ba(:\d+\.\w+)?\br(:\d+\.\w+)?\b_(:\d+\.\w+)?\b3(:\d+\.\w+)?\b0(:\d+\.\w+)?\b_(:\d+\.\w+)?\b1(:\d+\.\w+)?\b((:\d+\.\w+)?\b:(:\d+\.\w+)?\b\(:\d+\.\w+)?\bd(:\d+\.\w+)?\b+(:\d+\.\w+)?\b\(:\d+\.\w+)?\b.(:\d+\.\w+)?\b\(:\d+\.\w+)?\bw(:\d+\.\w+)?\b+(:\d+\.\w+)?\b)(:\d+\.\w+)?\b?(:\d+\.\w+)?\b\(:\d+\.\w+)?\bb(:\d+\.\w+)?\b
```

In this case, the problem is *\\b+*, but there are also other situations resulting e.g. in non-pair brackets.

This appears to be happening for example when one of initial variable names contains *&*, e.g.

```
['var_30_1', 'r2_3', 'var_40', '&var_37']
```

To increase resiliency, I would propose for now to add validation.